### PR TITLE
linting

### DIFF
--- a/packages/adapters-library/src/adapters/lynex/products/algebra/lynexAlgebralAdapter.ts
+++ b/packages/adapters-library/src/adapters/lynex/products/algebra/lynexAlgebralAdapter.ts
@@ -1,4 +1,4 @@
-import { formatUnits, getAddress } from 'ethers'
+import { getAddress } from 'ethers'
 import { SimplePoolAdapter } from '../../../../core/adapters/SimplePoolAdapter'
 import { AdaptersController } from '../../../../core/adaptersController'
 import { Chain } from '../../../../core/constants/chains'
@@ -31,7 +31,6 @@ import { PositionManager__factory } from '../../contracts'
 // Parameter needed for static call request
 // Set the date in the future to ensure the static call request doesn't trigger smart contract validation
 const deadline = Math.floor(Date.now() - 1000) + 60 * 10
-
 
 const positionManagerCommonAddress = getAddress(
   '0x5D3D9E20ad27dd61182505230D1bD075bd249E4B',
@@ -106,8 +105,7 @@ export class LynexAlgebraAdapter extends SimplePoolAdapter {
       name: 'Lynex Algebra',
       description: 'Lynex Algebra defi adapter',
       siteUrl: 'https://app.lynex.fi/',
-      iconUrl:
-        'https://app.lynex.fi/logo.png',
+      iconUrl: 'https://app.lynex.fi/logo.png',
       positionType: PositionType.Supply,
       chainId: this.chainId,
       productId: this.productId,
@@ -137,7 +135,6 @@ export class LynexAlgebraAdapter extends SimplePoolAdapter {
 
     return filterMapAsync(tokenIds, async (tokenId) => {
       try {
-
         const position = await positionsManagerContract.positions(tokenId, {
           blockTag: blockNumber,
         })
@@ -177,7 +174,7 @@ export class LynexAlgebraAdapter extends SimplePoolAdapter {
 
         const nftName = this.protocolTokenName(
           token0Metadata.symbol,
-          token1Metadata.symbol
+          token1Metadata.symbol,
         )
 
         return {
@@ -247,10 +244,7 @@ export class LynexAlgebraAdapter extends SimplePoolAdapter {
     )
   }
 
-  private protocolTokenName(
-    token0Symbol: string,
-    token1Symbol: string,
-  ) {
+  private protocolTokenName(token0Symbol: string, token1Symbol: string) {
     return `${token0Symbol} / ${token1Symbol}`
   }
 
@@ -376,11 +370,11 @@ export class LynexAlgebraAdapter extends SimplePoolAdapter {
             address: protocolTokenAddress,
             name: this.protocolTokenName(
               token0Metadata.symbol,
-              token1Metadata.symbol
+              token1Metadata.symbol,
             ),
             symbol: this.protocolTokenName(
               token0Metadata.symbol,
-              token1Metadata.symbol
+              token1Metadata.symbol,
             ),
             decimals: 18,
             tokenId,

--- a/packages/adapters-library/src/adapters/lynex/products/classic/lynexClassicAdapter.ts
+++ b/packages/adapters-library/src/adapters/lynex/products/classic/lynexClassicAdapter.ts
@@ -4,20 +4,18 @@ import {
 } from '../../../../core/adapters/UniswapV2PoolForkAdapter'
 import { Chain } from '../../../../core/constants/chains'
 import { CacheToFile } from '../../../../core/decorators/cacheToFile'
-import { NotImplementedError } from '../../../../core/errors/errors'
 import {
   AssetType,
   PositionType,
   ProtocolDetails,
 } from '../../../../types/adapter'
-import { Protocol } from '../../../protocols'
 
 export class LynexClassicAdapter extends UniswapV2PoolForkAdapter {
   productId = 'classic'
 
   // TODO: Ammend this if pairs grow over 1,000
   protected override readonly MIN_SUBGRAPH_VOLUME: number = -1
-  protected override  readonly MIN_TOKEN_RESERVE: number = 0
+  protected override readonly MIN_TOKEN_RESERVE: number = 0
 
   getProtocolDetails(): ProtocolDetails {
     return {
@@ -25,8 +23,7 @@ export class LynexClassicAdapter extends UniswapV2PoolForkAdapter {
       name: 'Lynex',
       description: 'Lynex classic pool adapter',
       siteUrl: 'https://app.lynex.fi/',
-      iconUrl:
-        'https://app.lynex.fi/logo.png',
+      iconUrl: 'https://app.lynex.fi/logo.png',
       positionType: PositionType.Supply,
       chainId: this.chainId,
       productId: this.productId,
@@ -45,7 +42,8 @@ export class LynexClassicAdapter extends UniswapV2PoolForkAdapter {
     return {
       [Chain.Linea]: {
         type: 'graphql',
-        subgraphUrl: 'https://api.studio.thegraph.com/query/59052/lynex-v1/v0.1.0',
+        subgraphUrl:
+          'https://api.studio.thegraph.com/query/59052/lynex-v1/v0.1.0',
         factoryAddress: '0xBc7695Fd00E3b32D08124b7a4287493aEE99f9ee',
       },
     }
@@ -56,4 +54,3 @@ export class LynexClassicAdapter extends UniswapV2PoolForkAdapter {
     return super.buildMetadata()
   }
 }
-

--- a/packages/adapters-library/src/adapters/lynex/tests/testCases.ts
+++ b/packages/adapters-library/src/adapters/lynex/tests/testCases.ts
@@ -1,7 +1,6 @@
 import { Chain } from '../../../core/constants/chains'
 import { TimePeriod } from '../../../core/constants/timePeriod'
 import type { TestCase } from '../../../types/testCase'
-import { WriteActions } from '../../../types/writeActions'
 
 export const testCases: TestCase[] = [
   {


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request. Include relevant links to the protocol docs
-->

## **Pre-merge author checklist**

- [ ] A brief description of the protocol and adapters is added to the PR
- [ ] Files outside the protocol folder are not being edited and, if they are, it's clearly explained why in the PR
- [ ] `update me` comments are removed
- [ ] Contracts used are verified for that chain block explorer
- [ ] Test cases with a block number have been added to the `testCases.ts` file for every relevant method that has been implemented
  - [ ] positions
  - [ ] prices
  - [ ] deposits
  - [ ] withdrawals
  - [ ] profits
  - [ ] tvl
  - [ ] apr
  - [ ] apy
- [ ] `getAddress` from `ethers`
  - [ ] Is used to parse hardcoded addresses
  - [ ] Is used to parse addresses that come from contract calls when it is not clear they'll be in checksum format
  - [ ] It is NOT used to parse addresses from input methods
  - [ ] It is NOT used to parse addresses from metadata
- [ ] For every adapter that extends `SimplePoolAdapter`
  - [ ] `getPositions` is not overwritten and, if it is, it's clearly explained why in the PR
  - [ ] `unwrap` is not overwritten and, if it is, it's clearly explained why in the PR
- [ ] If the adapters requires to fetch static data on-chain (e.g. pool ids, token metadata, etc)
  - [ ] The adapter implements `IMetadataBuilder`
  - [ ] The `buildMetadata` method is implemented with the `@CacheToFile` decorator
  - [ ] All the static data is stored within the metadata JSON file
